### PR TITLE
DIV-5845: Removed self as default directive for CSP

### DIFF
--- a/middleware/helmet.js
+++ b/middleware/helmet.js
@@ -9,7 +9,6 @@ const setupHelmet = app => {
   // Helmet content security policy (CSP) to allow only assets from same domain.
   app.use(helmet.contentSecurityPolicy({
     directives: {
-      defaultSrc: ['\'self\''],
       fontSrc: ['\'self\' data:'],
       scriptSrc: ['\'self\'', '\'unsafe-inline\'', 'www.google-analytics.com', 'vcc-eu4.8x8.com', 'vcc-eu4b.8x8.com'],
       connectSrc: ['\'self\''],

--- a/test/unit/middleware/helmet.test.js
+++ b/test/unit/middleware/helmet.test.js
@@ -23,7 +23,6 @@ describe(modulePath, () => {
 
     sinon.assert.calledWith(contentSecurityPolicyStub, {
       directives: {
-        defaultSrc: ['\'self\''],
         fontSrc: ['\'self\' data:'],
         scriptSrc: [
           '\'self\'',


### PR DESCRIPTION
This is to fix an issue we're experiencing in production with Chrome where the documents are not being rendered correctly due to:
"Refused to apply inline style because it violates the following Content Security Policy directive: "default-src 'self'". Either the 'unsafe-inline' keyword, a hash ('sha256-tbWZ4NP1341cpcrZVDn7B3o9bt/muXgduILAnC0Zbaw='), or a nonce ('nonce-...') is required to enable inline execution. Note also that 'style-src' was not explicitly set, so 'default-src' is used as a fallback."
The line of code that caused this was not present in DN/RFE & so those apps are unaffected by this issue
Jira: https://tools.hmcts.net/jira/browse/DIV-5845
ServiceNow Incident: INC0511049