### PR TITLE
DIV-5756 - Enable webchat on live environment

### DIFF
--- a/charts/div-da/values.yaml
+++ b/charts/div-da/values.yaml
@@ -40,8 +40,6 @@ nodejs:
         PETITIONER_FRONTEND_URL: "https://div-pfe-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
         RESPONDENT_FRONTEND_URL: "https://div-rfe-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
         DECREE_NISI_FRONTEND_URL: "https://div-dn-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
-
-        FEATURE_WEBCHAT: "true"
     keyVaults:
         div:
             secrets:

--- a/config/default.yml
+++ b/config/default.yml
@@ -122,7 +122,7 @@ tests:
 
 features:
   idam: false
-  webchat: false
+  webchat: true
 
 journey:
   timeoutDelay: 300

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -208,7 +208,7 @@ variable "appinsights_instrumentation_key" {
 }
 
 variable "feature_webchat" {
-  default = false
+  default = true
 }
 
 variable "webchat_chat_id" {


### PR DESCRIPTION
# Description

[DIV-5756 - Enable webchat on live environment](https://tools.hmcts.net/jira/browse/DIV-5756)
 - Remove chart specific config
 - Set webchat default to true
 - Set webchat default on true for PROD and AAT environments