### PR TITLE
remove yarn audit as its now run elsewhere

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -34,16 +34,6 @@ withPipeline("nodejs", product, component) {
       yarnBuilder.yarn('test:validation')
       yarnBuilder.yarn('test:a11y')
     }
-
-    stage('Audit') {
-      try {
-        yarnBuilder.yarn('audit')
-      } catch (error) {
-        onMaster {
-          slackSend(channel: '#div-dev', color: 'warning', message: "Yarn Audit has detected vulnerabilities in ${env.JOB_NAME}. You can check if there are patches for them in the full report, build details here: <${env.RUN_DISPLAY_URL}|Build ${env.BUILD_DISPLAY_NAME}>.")
-        }
-      }
-    }
   }
 
   before('functionalTest:aks') {


### PR DESCRIPTION
Yarn Audit is now run accross all pipelines and does need to be run from here
See Slack post regarding this https://hmcts-reform.slack.com/files/T1L0WSW9F/F017802QYEQ
**Not to be merged** until confirmation that the above has been implemented so that we still have coverage.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
